### PR TITLE
Add Linux ARM64 (aarch64) support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@ async function downloadBleep(version: string): Promise<void> {
 
   if (process.platform === 'linux' && process.arch === 'x64') {
     unixLike(`${baseUrl}-x86_64-pc-linux.tar.gz`)
+  } else if (process.platform === 'linux' && process.arch === 'arm64') {
+    unixLike(`${baseUrl}-arm64-pc-linux.tar.gz`)
   } else if (process.platform === 'win32' && process.arch === 'x64') {
     const guid = await tc.downloadTool(`${baseUrl}-x86_64-pc-win32.zip`)
     const extracted = await tc.extractZip(guid)


### PR DESCRIPTION
Adds `linux/arm64` platform detection to download `bleep-arm64-pc-linux.tar.gz` on ARM64 GitHub Actions runners.

Companion to oyvindberg/bleep#529 which adds the ARM64 native image build to bleep's CI. This PR should be merged after bleep publishes its first release with the ARM64 binary.

Note: `dist/index.js` needs rebuilding after merge (`npm run all`).